### PR TITLE
Allow GAME_TEXTURE to share from other GAME_TEXTURE or descendants

### DIFF
--- a/game_core/graphic/game_texture.e
+++ b/game_core/graphic/game_texture.e
@@ -56,7 +56,7 @@ feature {NONE} -- Initialization
 			Is_Not_Shared: not shared
 		end
 
-	share_from_other(a_other:like Current)
+	share_from_other(a_other: GAME_TEXTURE)
 			-- Initialization of `Current' sharing the internal data of `Current'
 			-- Note that each modification of `Current' will affect `a_other' and
 			-- vice versa


### PR DESCRIPTION
Don't use anchored type as parameter in {GAME_TEXTURE}.share_from_other to allow descendants to use it with plain GAME_TEXTUREs instead of their own type.