### PR TITLE
Fix failing assertion when additional color is not opaque

### DIFF
--- a/game_core/graphic/game_color_readable.e
+++ b/game_core/graphic/game_color_readable.e
@@ -117,7 +117,13 @@ feature -- Access
 	is_equal(a_color:like Current):BOOLEAN
 			-- <Precursor>
 		do
-			result:=a_color.red=red and a_color.green=green and a_color.blue=blue and a_color.alpha=alpha
+			result:=is_equal_ignore_alpha(a_color) and a_color.alpha=alpha
+		end
+
+	is_equal_ignore_alpha(a_color:like Current):BOOLEAN
+			-- Are `Current' and `a_other' identical, regardless of alpha?
+		do
+			result:=a_color.red=red and a_color.green=green and a_color.blue=blue
 		end
 
 	out:STRING_8

--- a/game_core/graphic/game_texture.e
+++ b/game_core/graphic/game_texture.e
@@ -266,9 +266,9 @@ feature -- Access
 											a_additionnal_color.red,
 											a_additionnal_color.green,
 											a_additionnal_color.blue)
-			manage_error_code(l_error, "Cannot set the texture additionnal alpha value")
+			manage_error_code(l_error, "Cannot set the texture additionnal color value")
 		ensure
-			Is_Set: additionnal_color.is_equal(a_additionnal_color)
+			Is_Set: additionnal_color.is_equal_ignore_alpha(a_additionnal_color)
 		end
 
 feature {NONE} -- Measurement


### PR DESCRIPTION
Since {GAME_TEXTURE}.additionnal_color always returns an opaque color, {GAME_TEXTURE}.set_additionnal_color fails when a_additionnal_color is not opaque because the alpha is taken into consideration in the comparison.