### PR TITLE
Export {GAME_KEY_STATE}.modifier to facilitate input handling

### DIFF
--- a/game_core/event/game_key_state.e
+++ b/game_core/event/game_key_state.e
@@ -128,7 +128,7 @@ feature -- Access
 			Result := modifier.bit_or ({GAME_SDL_EXTERNAL}.KMOD_GUI) /= 0
 		end
 
-feature {NONE} -- Implementation
+feature -- Implementation
 
 	repeat:NATURAL_8
 			-- Not 0 when the key event is an automatic repeted event


### PR DESCRIPTION
For my implementation, I need to access the modifier attribute of {GAME_KEY_STATE} directly. This makes it possible to differentiate e.g. <A> and <Ctrl+A> transparently.