### PR TITLE
Consistency and Translation

### DIFF
--- a/audio/implementation/audio_external.e
+++ b/audio/implementation/audio_external.e
@@ -8,7 +8,7 @@ class
 	AUDIO_EXTERNAL
 
 
-feature -- OpenAL functions
+feature -- OpenAL Functions
 
 
 	frozen AL_get_error:INTEGER
@@ -227,7 +227,7 @@ feature -- OpenAL functions
 			"alSourceRewind"
 		end
 
-feature -- OpenAL Constantes
+feature -- OpenAL Constants
 
 
 


### PR DESCRIPTION
consistency of "Functions" and "Constants", one had a capital letter and
the other didn't.

Constantes -> Constants