### PR TITLE
Utiliser l'objet racine lors de la création de GAME_TEXTURE par partage

### DIFF
--- a/game_core/graphic/game_texture.e
+++ b/game_core/graphic/game_texture.e
@@ -62,14 +62,23 @@ feature {NONE} -- Initialization
 			-- vice versa
 		require
 			Other_Exists: a_other.exists
+		local
+			l_root: like other
 		do
-			make_by_pointer (a_other.item)
-			other := a_other
+			from
+				l_root := a_other
+			until
+				not l_root.shared
+			loop
+				l_root := l_root.other
+			end
+			make_by_pointer (l_root.item)
+			other := l_root
 			shared := True
 		ensure
 			Is_Created: exists
 			Is_Shared: shared
-			Other_Assign: attached other
+			Other_Assign: attached other and then not other.shared
 		end
 
 	make(a_renderer:GAME_RENDERER; a_pixel_format:GAME_PIXEL_FORMAT_READABLE;
@@ -304,6 +313,7 @@ feature {NONE} -- Implementation
 			end
 		end
 
+feature {GAME_TEXTURE} -- Implementation
 
 	other:detachable GAME_TEXTURE
 			-- If `Current' has been created with `share_from_other',


### PR DESCRIPTION
L'implémentation actuelle de `{GAME_TEXTURE}.share_from_other` conserve une référence à l'argument reçu, ce qui peut empêcher des objets d'être collectés par le garbage collector si une chaîne de références est créée.

Exemple:

    create {GAME_TEXTURE} texture_racine.make ...
    create {GAME_TEXTURE} texture_1.share_from_other(texture_racine)
    create {GAME_TEXTURE} texture_2.share_from_other(texture_1)
    texture_1 := void
 
`texture_2` référence `texture_1` qui référence à son tour `texture_racine`, empêchant `texture_1` d'être collectée. Je n'ai pas testé mais je suppose que la performance des opérations de dessin est également affectée.

Mon changement fait en sorte que seul l'objet racine soit conservé `texture_2` référence alors directement `texture_racine`, donc `texture_1` peut être collectée.