### PR TITLE
Mention git submodules in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Installation on Linux (Ubuntu)
 ------------------------------
 
 * I assume that you already have a fonctionnal EiffelStudio on your system. If not, install it.
+* If you obtained library sources by cloning the git repository, fetch submodules (run `git submodule init` and `git submodule update` in the library folder)
 * Rename the library folder (containing this README.md) to "game2".
 * You need to add the game2 folder library in the "contrib/library" folder of EiffelStudio. Normaly, this folder is in "/usr/lib/EiffelStudio_XX.XX" or in "/usr/local/Eiffel_XX.XX".
 


### PR DESCRIPTION
I propose a tiny addition to the installation instructions.

Not being very familiar with this git feature, I was at first quite confused when I checked the library out, compiled it, tried to build [an application](https://github.com/ZeLarpMaster/MP3Player) and compilation failed on attempt to load some ecf from the empty `eiffel_chain_indexable_iterator` directory.