### PR TITLE
Simplifier l'invariant d'événement de souris

### DIFF
--- a/game_core/event/game_mouse_button_event.e
+++ b/game_core/event/game_mouse_button_event.e
@@ -9,14 +9,16 @@ deferred class
 
 inherit
 
-	ANY
+	GAME_MOUSE_EVENTS_STATE
+		rename
+			make as make_events_state
 		undefine
 			default_create
 		end
 
 inherit {NONE}
 
-	GAME_MOUSE_MOTION_STATE
+	GAME_MOUSE_STATE
 		rename
 			state as button_id,
 			is_left_button_pressed as is_left_button,
@@ -25,7 +27,6 @@ inherit {NONE}
 			is_optionnal_button_1_pressed as is_optional_button_1,
 			is_optionnal_button_2_pressed as is_optional_button_2
 		redefine
-			make,
 			is_left_button,
 			is_right_button,
 			is_middle_button,
@@ -38,7 +39,10 @@ feature {NONE} -- Initialization
 	make (a_mouse_id, a_button_id: NATURAL_32; a_x, a_y: INTEGER_32)
 			-- Initialization for `Current'.
 		do
-			Precursor {GAME_MOUSE_MOTION_STATE} (a_mouse_id, a_button_id, a_x, a_y)
+			make_events_state (a_mouse_id)
+			button_id := a_button_id
+			x := a_x
+			y := a_y
 		end
 
 feature -- Access

--- a/game_core/event/game_mouse_button_event.e
+++ b/game_core/event/game_mouse_button_event.e
@@ -1,7 +1,10 @@
 note
-	description: "The state of a mouse button event"
-	author: "Louis Marchand"
-	date: "Thu, 02 Apr 2015 02:40:10 +0000"
+	description: "[
+		Encapsulates a mouse button event.
+		Any instance represents one button only.
+	]"
+	author: "Louis Marchand and obnosim"
+	date: "Sun Feb 04, 2018"
 	revision: "2.0"
 
 deferred class
@@ -9,40 +12,20 @@ deferred class
 
 inherit
 
-	GAME_MOUSE_EVENTS_STATE
-		rename
-			make as make_events_state
-		undefine
-			default_create
-		end
-
-inherit {NONE}
-
-	GAME_MOUSE_STATE
+	GAME_MOUSE_EVENT
 		rename
 			state as button_id,
-			is_left_button_pressed as is_left_button,
-			is_right_button_pressed as is_right_button,
-			is_middle_button_pressed as is_middle_button,
-			is_optionnal_button_1_pressed as is_optional_button_1,
-			is_optionnal_button_2_pressed as is_optional_button_2
+			has_left_button as is_left_button,
+			has_right_button as is_right_button,
+			has_middle_button as is_middle_button,
+			has_optional_button_1 as is_optional_button_1,
+			has_optional_button_2 as is_optional_button_2
 		redefine
 			is_left_button,
 			is_right_button,
 			is_middle_button,
 			is_optional_button_1,
 			is_optional_button_2
-		end
-
-feature {NONE} -- Initialization
-
-	make (a_mouse_id, a_button_id: NATURAL_32; a_x, a_y: INTEGER_32)
-			-- Initialization for `Current'.
-		do
-			make_events_state (a_mouse_id)
-			button_id := a_button_id
-			x := a_x
-			y := a_y
 		end
 
 feature -- Access
@@ -78,6 +61,6 @@ feature -- Access
 		end
 
 invariant
-	Only_One_Button: is_left_button xor is_right_button xor is_middle_button xor is_optional_button_1 xor is_optional_button_2
+	Only_One_Button: is_left_button.to_integer + is_right_button.to_integer + is_middle_button.to_integer + is_optional_button_1.to_integer + is_optional_button_2.to_integer = 1
 
 end

--- a/game_core/event/game_mouse_button_event.e
+++ b/game_core/event/game_mouse_button_event.e
@@ -1,0 +1,79 @@
+note
+	description: "The state of a mouse button event"
+	author: "Louis Marchand"
+	date: "Thu, 02 Apr 2015 02:40:10 +0000"
+	revision: "2.0"
+
+deferred class
+	GAME_MOUSE_BUTTON_EVENT
+
+inherit
+
+	ANY
+		undefine
+			default_create
+		end
+
+inherit {NONE}
+
+	GAME_MOUSE_MOTION_STATE
+		rename
+			state as button_id,
+			is_left_button_pressed as is_left_button,
+			is_right_button_pressed as is_right_button,
+			is_middle_button_pressed as is_middle_button,
+			is_optionnal_button_1_pressed as is_optional_button_1,
+			is_optionnal_button_2_pressed as is_optional_button_2
+		redefine
+			make,
+			is_left_button,
+			is_right_button,
+			is_middle_button,
+			is_optional_button_1,
+			is_optional_button_2
+		end
+
+feature {NONE} -- Initialization
+
+	make (a_mouse_id, a_button_id: NATURAL_32; a_x, a_y: INTEGER_32)
+			-- Initialization for `Current'.
+		do
+			Precursor {GAME_MOUSE_MOTION_STATE} (a_mouse_id, a_button_id, a_x, a_y)
+		end
+
+feature -- Access
+
+	is_left_button: BOOLEAN
+			-- Is the left button of the mouse the one represented by `Current'?
+		do
+			Result := button_id = {GAME_SDL_EXTERNAL}.SDL_BUTTON_LEFT
+		end
+
+	is_right_button: BOOLEAN
+			-- Is the right button of the mouse the one represented by `Current'?
+		do
+			Result := button_id = {GAME_SDL_EXTERNAL}.SDL_BUTTON_RIGHT
+		end
+
+	is_middle_button: BOOLEAN
+			-- Is the middle button of the mouse the one represented by `Current'?
+		do
+			Result := button_id = {GAME_SDL_EXTERNAL}.SDL_BUTTON_MIDDLE
+		end
+
+	is_optional_button_1: BOOLEAN
+			-- Is the first optional button of the mouse the one represented by `Current'?
+		do
+			Result := button_id = {GAME_SDL_EXTERNAL}.SDL_BUTTON_X1
+		end
+
+	is_optional_button_2: BOOLEAN
+			-- Is the second optional button of the mouse the one represented by `Current'?
+		do
+			Result := button_id = {GAME_SDL_EXTERNAL}.SDL_BUTTON_X2
+		end
+
+invariant
+	Only_One_Button: is_left_button xor is_right_button xor is_middle_button xor is_optional_button_1 xor is_optional_button_2
+
+end

--- a/game_core/event/game_mouse_button_press_event.e
+++ b/game_core/event/game_mouse_button_press_event.e
@@ -1,0 +1,20 @@
+note
+	description: "[
+		Encapsulates the press of a mouse button
+	]"
+	author: "Louis Marchand and obnosim"
+	date: "Sun Feb 04, 2018"
+	revision: "2.0"
+	todo: "Drop GAME_MOUSE_BUTTON_RELEASED_STATE entirely and inherit GAME_MOUSE_BUTTON_EVENT directly"
+
+class
+	GAME_MOUSE_BUTTON_PRESS_EVENT
+
+inherit
+
+	GAME_MOUSE_BUTTON_PRESSED_STATE
+
+create
+	make
+
+end

--- a/game_core/event/game_mouse_button_pressed_state.e
+++ b/game_core/event/game_mouse_button_pressed_state.e
@@ -1,18 +1,18 @@
 note
 	description: "The state of a mouse button pressed event"
-	author: "Louis Marchand"
-	date: "Thu, 02 Apr 2015 02:40:10 +0000"
+	author: "Louis Marchand and obnosim"
+	date: "Sun Feb 04, 2018"
 	revision: "2.0"
 
-class
+deferred class
 	GAME_MOUSE_BUTTON_PRESSED_STATE
+
+obsolete
+	"Use GAME_MOUSE_BUTTON_PRESS_EVENT instead [2018-02-04]"
 
 inherit
 
 	GAME_MOUSE_BUTTON_EVENT
-
-create
-	make
 
 feature -- Access
 

--- a/game_core/event/game_mouse_button_pressed_state.e
+++ b/game_core/event/game_mouse_button_pressed_state.e
@@ -8,71 +8,57 @@ class
 	GAME_MOUSE_BUTTON_PRESSED_STATE
 
 inherit
-	GAME_MOUSE_MOTION_STATE
-		rename
-			state as button_id
-		redefine
-			make,
-			is_left_button_pressed,
-			is_right_button_pressed,
-			is_middle_button_pressed,
-			is_optionnal_button_1_pressed,
-			is_optionnal_button_2_pressed
-		end
 
+	GAME_MOUSE_BUTTON_EVENT
 
 create
 	make
 
-feature {NONE} -- Initialization
-
-	make(a_mouse_id, a_button_id:NATURAL_32; a_x,a_y:INTEGER_32)
-			-- Initialization for `Current'.
-		do
-			Precursor {GAME_MOUSE_MOTION_STATE}(a_mouse_id, a_button_id, a_x, a_y)
-		end
-
 feature -- Access
 
-	is_left_button_pressed:BOOLEAN
+	is_left_button_pressed: BOOLEAN
 			-- Is the left button of the mouse represented
 			-- by `Current' is the one that has been pressed
+		obsolete
+			"Use `is_left_button' instead [2018-01-31]"
 		do
-			Result := button_id = {GAME_SDL_EXTERNAL}.SDL_BUTTON_LEFT
+			Result := is_left_button
 		end
 
-	is_right_button_pressed:BOOLEAN
+	is_right_button_pressed: BOOLEAN
 			-- Is the right button of the mouse represented
 			-- by `Current' is the one that has been pressed
+		obsolete
+			"Use `is_right_button' instead [2018-01-31]"
 		do
-			Result := button_id = {GAME_SDL_EXTERNAL}.SDL_BUTTON_RIGHT
+			Result := is_right_button
 		end
 
-	is_middle_button_pressed:BOOLEAN
+	is_middle_button_pressed: BOOLEAN
 			-- Is the middle button of the mouse represented
 			-- by `Current' is the one that has been pressed
+		obsolete
+			"Use `is_middle_button' instead [2018-01-31]"
 		do
-			Result := button_id = {GAME_SDL_EXTERNAL}.SDL_BUTTON_MIDDLE
+			Result := is_middle_button
 		end
 
-	is_optionnal_button_1_pressed:BOOLEAN
+	is_optionnal_button_1_pressed: BOOLEAN
 			-- Is the first optionnal button of the mouse represented
 			-- by `Current' is the one that has been pressed
+		obsolete
+			"Use `is_optional_button_1' instead [2018-01-31]"
 		do
-			Result := button_id = {GAME_SDL_EXTERNAL}.SDL_BUTTON_X1
+			Result := is_optional_button_1
 		end
 
-	is_optionnal_button_2_pressed:BOOLEAN
+	is_optionnal_button_2_pressed: BOOLEAN
 			-- Is the second optionnal button of the mouse represented
 			-- by `Current' is the one that has been pressed
+		obsolete
+			"Use `is_optional_button_2' instead [2018-01-31]"
 		do
-			Result := button_id = {GAME_SDL_EXTERNAL}.SDL_BUTTON_X2
+			Result := is_optional_button_2
 		end
 
-invariant
-	Only_One_Button: is_left_button_pressed
-					 xor is_right_button_pressed
-					 xor is_middle_button_pressed
-					 xor is_optionnal_button_1_pressed
-					 xor is_optionnal_button_2_pressed
 end

--- a/game_core/event/game_mouse_button_pressed_state.e
+++ b/game_core/event/game_mouse_button_pressed_state.e
@@ -70,41 +70,9 @@ feature -- Access
 		end
 
 invariant
--- This invariant has a wierd error on Linux with touch pad !
---	Only_One_Button:
---					(is_left_button_pressed and not (
---							is_right_button_pressed or
---							is_middle_button_pressed or
---							is_optionnal_button_1_pressed or
---							is_optionnal_button_2_pressed
---						)
---					) or
---					(is_right_button_pressed and not (
---							is_left_button_pressed or
---							is_middle_button_pressed or
---							is_optionnal_button_1_pressed or
---							is_optionnal_button_2_pressed
---						)
---					) or
---					(is_middle_button_pressed and not (
---							is_left_button_pressed or
---							is_right_button_pressed or
---							is_optionnal_button_1_pressed or
---							is_optionnal_button_2_pressed
---						)
---					) or
---					(is_optionnal_button_1_pressed and not (
---							is_right_button_pressed or
---							is_middle_button_pressed or
---							is_left_button_pressed or
---							is_optionnal_button_2_pressed
---						)
---					) or
---					(is_optionnal_button_2_pressed and not (
---							is_right_button_pressed or
---							is_middle_button_pressed or
---							is_left_button_pressed or
---							is_optionnal_button_1_pressed
---						)
---					)
+	Only_One_Button: is_left_button_pressed
+					 xor is_right_button_pressed
+					 xor is_middle_button_pressed
+					 xor is_optionnal_button_1_pressed
+					 xor is_optionnal_button_2_pressed
 end

--- a/game_core/event/game_mouse_button_release_event.e
+++ b/game_core/event/game_mouse_button_release_event.e
@@ -1,0 +1,20 @@
+note
+	description: "[
+		Encapsulates the release of a mouse button
+	]"
+	author: "Louis Marchand and obnosim"
+	date: "Sun Feb 04, 2018"
+	revision: "2.0"
+	todo: "Drop GAME_MOUSE_BUTTON_RELEASED_STATE entirely and inherit GAME_MOUSE_BUTTON_EVENT directly"
+
+class
+	GAME_MOUSE_BUTTON_RELEASE_EVENT
+
+inherit
+
+	GAME_MOUSE_BUTTON_RELEASED_STATE
+
+create
+	make
+
+end

--- a/game_core/event/game_mouse_button_released_state.e
+++ b/game_core/event/game_mouse_button_released_state.e
@@ -1,18 +1,18 @@
 note
 	description: "The state of a mouse button released event"
-	author: "Louis Marchand"
-	date: "Thu, 02 Apr 2015 02:40:10 +0000"
+	author: "Louis Marchand and obnosim"
+	date: "Sun Feb 04, 2018"
 	revision: "2.0"
 
-class
+deferred class
 	GAME_MOUSE_BUTTON_RELEASED_STATE
+
+obsolete
+	"Use GAME_MOUSE_BUTTON_RELEASE_EVENT instead [2018-02-04]"
 
 inherit
 
 	GAME_MOUSE_BUTTON_EVENT
-
-create
-	make
 
 feature -- Access
 

--- a/game_core/event/game_mouse_button_released_state.e
+++ b/game_core/event/game_mouse_button_released_state.e
@@ -8,58 +8,57 @@ class
 	GAME_MOUSE_BUTTON_RELEASED_STATE
 
 inherit
-	GAME_MOUSE_BUTTON_PRESSED_STATE
-		rename
-			is_left_button_pressed as is_left_button_released,
-			is_right_button_pressed as is_right_button_released,
-			is_middle_button_pressed as is_middle_button_released,
-			is_optionnal_button_1_pressed as is_optionnal_button_1_released,
-			is_optionnal_button_2_pressed as is_optionnal_button_2_released
-		redefine
-			is_left_button_released,
-			is_right_button_released,
-			is_middle_button_released,
-			is_optionnal_button_1_released,
-			is_optionnal_button_2_released
-		end
+
+	GAME_MOUSE_BUTTON_EVENT
 
 create
 	make
 
 feature -- Access
 
-	is_left_button_released:BOOLEAN
+	is_left_button_released: BOOLEAN
 			-- Is the left button of the mouse represented
 			-- by `Current' is the one that has been released
+		obsolete
+			"Use `is_left_button' instead [2018-01-31]"
 		do
-			Result := Precursor {GAME_MOUSE_BUTTON_PRESSED_STATE}
+			Result := is_left_button
 		end
 
-	is_right_button_released:BOOLEAN
+	is_right_button_released: BOOLEAN
 			-- Is the right button of the mouse represented
 			-- by `Current' is the one that has been released
+		obsolete
+			"Use `is_right_button' instead [2018-01-31]"
 		do
-			Result := Precursor {GAME_MOUSE_BUTTON_PRESSED_STATE}
+			Result := is_right_button
 		end
 
-	is_middle_button_released:BOOLEAN
+	is_middle_button_released: BOOLEAN
 			-- Is the middle button of the mouse represented
 			-- by `Current' is the one that has been released
+		obsolete
+			"Use `is_middle_button' instead [2018-01-31]"
 		do
-			Result := Precursor {GAME_MOUSE_BUTTON_PRESSED_STATE}
+			Result := is_middle_button
 		end
 
-	is_optionnal_button_1_released:BOOLEAN
+	is_optionnal_button_1_released: BOOLEAN
 			-- Is the first optionnal button of the mouse represented
 			-- by `Current' is the one that has been released
+		obsolete
+			"Use `is_optional_button_1' instead [2018-01-31]"
 		do
-			Result := Precursor {GAME_MOUSE_BUTTON_PRESSED_STATE}
+			Result := is_optional_button_1
 		end
 
-	is_optionnal_button_2_released:BOOLEAN
+	is_optionnal_button_2_released: BOOLEAN
 			-- Is the second optionnal button of the mouse represented
 			-- by `Current' is the one that has been released
+		obsolete
+			"Use `is_optional_button_2' instead [2018-01-31]"
 		do
-			Result := Precursor {GAME_MOUSE_BUTTON_PRESSED_STATE}
+			Result := is_optional_button_2
 		end
+
 end

--- a/game_core/event/game_mouse_event.e
+++ b/game_core/event/game_mouse_event.e
@@ -1,0 +1,68 @@
+note
+	description: "[
+		Common interface for various mouse input events
+	]"
+	author: "Louis Marchand and obnosim"
+	date: "Sun Feb 04, 2018"
+	revision: "$Revision$"
+
+deferred class
+	GAME_MOUSE_EVENT
+
+inherit
+
+	GAME_MOUSE_EVENT_ORIGIN
+		rename
+			make as set_id
+		end
+
+feature {NONE} -- Initialization
+
+	make (a_mouse_id, a_state: NATURAL_32; a_x, a_y: INTEGER_32)
+			-- Initialization for `Current'.
+		do
+			set_id (a_mouse_id)
+			state := a_state
+			x := a_x
+			y := a_y
+		end
+
+feature -- Access
+
+	x: INTEGER_32
+			-- Horizontal position of the mouse represented by `Current' relative to the focussed window
+
+	y: INTEGER_32
+			-- Vertical position of the mouse represented by `Current' relative to the focussed window
+
+	has_left_button: BOOLEAN
+			-- Is the left button of the mouse that emitted `Current' involved with `Current'?
+		deferred
+		end
+
+	has_right_button: BOOLEAN
+			-- Is the right button of the mouse that emitted `Current' involved with `Current'?
+		deferred
+		end
+
+	has_middle_button: BOOLEAN
+			-- Is the middle button of the mouse that emitted `Current' involved with `Current'?
+		deferred
+		end
+
+	has_optional_button_1: BOOLEAN
+			-- Is the first optional button of the mouse that emitted `Current' involved with `Current'?
+		deferred
+		end
+
+	has_optional_button_2: BOOLEAN
+			-- Is the second optional button of the mouse that emitted `Current' involved with `Current'?
+		deferred
+		end
+
+feature {GAME_SDL_ANY} -- Implementation
+
+	state: NATURAL_32
+			-- The internal state code.
+
+end

--- a/game_core/event/game_mouse_event_origin.e
+++ b/game_core/event/game_mouse_event_origin.e
@@ -5,14 +5,14 @@ note
 	revision: "2.0"
 
 class
-	GAME_MOUSE_EVENTS_STATE
+	GAME_MOUSE_EVENT_ORIGIN
 
 create
 	make
 
 feature {NONE} -- Initialization
 
-	make(a_mouse_id:NATURAL_32)
+	make (a_mouse_id: NATURAL_32)
 			-- Initialization of `Current' using `a_mouse_id' as internal `id'
 		do
 			id := a_mouse_id
@@ -20,10 +20,10 @@ feature {NONE} -- Initialization
 
 feature -- Access
 
-	id:NATURAL_32
+	id: NATURAL_32
 			-- Unique identifier of the mouse represented by `Current'
 
-	is_touch_device:BOOLEAN
+	is_touch_device: BOOLEAN
 			-- True if the mouse represented by `Current' is the touch device.
 		do
 			Result := id = {GAME_SDL_EXTERNAL}.SDL_TOUCH_MOUSEID

--- a/game_core/event/game_mouse_motion_state.e
+++ b/game_core/event/game_mouse_motion_state.e
@@ -1,34 +1,74 @@
 note
-	description: "Summary description for {GAME_MOUSE_MOTION_STATE}."
-	author: "Louis Marchand"
-	date: "Thu, 02 Apr 2015 02:40:10 +0000"
+	description: "[
+		Encapsulates the state of a mouse during a movement
+	]"
+	author: "Louis Marchand and obnosim"
+	date: "Sun Feb 04, 2018"
 	revision: "2.0"
 
 class
 	GAME_MOUSE_MOTION_STATE
 
 inherit
-	GAME_MOUSE_STATE
-	GAME_MOUSE_EVENTS_STATE
+
+	GAME_MOUSE_EVENT
 		rename
-			make as make_events_state
-		undefine
-			default_create
+			has_left_button as is_left_button_pressed,
+			has_right_button as is_right_button_pressed,
+			has_middle_button as is_middle_button_pressed,
+			has_optional_button_1 as is_optional_button_1_pressed,
+			has_optional_button_2 as is_optional_button_2_pressed
 		end
 
 create
 	make
 
-feature {NONE} -- Initialization
+feature -- Access
 
-	make(a_mouse_id, a_state:NATURAL_32; a_x,a_y:INTEGER_32)
-			-- Initialization for `Current'.
+	is_left_button_pressed: BOOLEAN
+			-- Was the left button pressed when `Current' was emitted?
 		do
-			make_events_state(a_mouse_id)
-			state := a_state
-			x := a_x
-			y := a_y
+			result := (state.bit_and ({GAME_SDL_EXTERNAL}.SDL_BUTTON_LMASK) /= 0)
 		end
 
+	is_right_button_pressed: BOOLEAN
+			-- Was the right button pressed when `Current' was emitted?
+		do
+			result := (state.bit_and ({GAME_SDL_EXTERNAL}.SDL_BUTTON_RMASK) /= 0)
+		end
+
+	is_middle_button_pressed: BOOLEAN
+			-- Was the middle button pressed when `Current' was emitted?
+		do
+			result := (state.bit_and ({GAME_SDL_EXTERNAL}.SDL_BUTTON_MMASK) /= 0)
+		end
+
+	is_optional_button_1_pressed: BOOLEAN
+			-- Was the first optional button pressed when `Current' was emitted?
+		do
+			result := (state.bit_and ({GAME_SDL_EXTERNAL}.SDL_BUTTON_X1MASK) /= 0)
+		end
+
+	is_optionnal_button_1_pressed: BOOLEAN
+			-- Was the first optional button pressed when `Current' was emitted?
+		obsolete
+			"Use is_optional_button_1_pressed instead [2018-02-04]"
+		do
+			result := is_optional_button_1_pressed
+		end
+
+	is_optional_button_2_pressed: BOOLEAN
+			-- Was the second optional button pressed when `Current' was emitted?
+		do
+			result := (state.bit_and ({GAME_SDL_EXTERNAL}.SDL_BUTTON_X2MASK) /= 0)
+		end
+
+	is_optionnal_button_2_pressed: BOOLEAN
+			-- Was the second optional button pressed when `Current' was emitted?
+		obsolete
+			"Use is_optional_button_2_pressed instead [2018-02-04]"
+		do
+			result := is_optional_button_2_pressed
+		end
 
 end

--- a/game_core/event/game_window_events.e
+++ b/game_core/event/game_window_events.e
@@ -465,7 +465,7 @@ feature -- Access
 			end
 		end
 
-	mouse_button_pressed_actions: ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_BUTTON_PRESSED_STATE;
+	mouse_button_pressed_actions: ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_BUTTON_PRESS_EVENT;
 																	nb_clicks:NATURAL_8]]
 			-- When a mouse represented by `mouse_state' has been pressed for the `nb_clicks' times
 		require
@@ -482,7 +482,7 @@ feature -- Access
 			end
 		end
 
-	mouse_button_released_actions: ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_BUTTON_RELEASED_STATE;
+	mouse_button_released_actions: ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_BUTTON_RELEASE_EVENT;
 																	nb_clicks:NATURAL_8]]
 			-- When a mouse represented by `mouse_state' has been released for the `nb_clicks' times
 		require
@@ -499,7 +499,7 @@ feature -- Access
 			end
 		end
 
-	mouse_wheel_move_actions: ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_EVENTS_STATE;
+	mouse_wheel_move_actions: ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_EVENT_ORIGIN;
 																	delta_x,delta_y:INTEGER_32]]
 			-- When the wheel of a mouse represented by `mouse_state' has been moved.
 			-- The difference between the old wheel position and the new one is (`delta_x',`delta_y')
@@ -748,7 +748,7 @@ feature {NONE} -- Implementation
 			end
 		end
 
-	mouse_button_pressed_actions_internal: detachable ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_BUTTON_PRESSED_STATE;
+	mouse_button_pressed_actions_internal: detachable ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_BUTTON_PRESS_EVENT;
 																	nb_clicks:NATURAL_8]]
 			-- Internal value of the `mouse_button_pressed_actions' lazy evaluated attribute
 
@@ -762,7 +762,7 @@ feature {NONE} -- Implementation
 			-- The dispatcher receiving event from the `mouse_button_pressed_events_callback' and dispatch them to
 			-- the `mouse_button_pressed_actions' {ACTION_SEQUENCE}
 		local
-			l_mouse_state:GAME_MOUSE_BUTTON_PRESSED_STATE
+			l_mouse_state:GAME_MOUSE_BUTTON_PRESS_EVENT
 		do
 			if a_window_id =id or a_window_id = 0 then
 				if attached mouse_button_pressed_actions_internal as actions then
@@ -772,7 +772,7 @@ feature {NONE} -- Implementation
 			end
 		end
 
-	mouse_button_released_actions_internal: detachable ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_BUTTON_RELEASED_STATE;
+	mouse_button_released_actions_internal: detachable ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_BUTTON_RELEASE_EVENT;
 																	nb_clicks:NATURAL_8]]
 			-- Internal value of the `mouse_button_released_actions' lazy evaluated attribute
 
@@ -786,7 +786,7 @@ feature {NONE} -- Implementation
 			-- The dispatcher receiving event from the `mouse_button_released_events_callback' and dispatch them to
 			-- the `mouse_button_released_actions' {ACTION_SEQUENCE}
 		local
-			l_mouse_state:GAME_MOUSE_BUTTON_RELEASED_STATE
+			l_mouse_state:GAME_MOUSE_BUTTON_RELEASE_EVENT
 		do
 			if a_window_id =id or a_window_id = 0 then
 				if attached mouse_button_released_actions_internal as actions then
@@ -796,7 +796,7 @@ feature {NONE} -- Implementation
 			end
 		end
 
-	mouse_wheel_move_actions_internal: detachable ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_EVENTS_STATE;
+	mouse_wheel_move_actions_internal: detachable ACTION_SEQUENCE[TUPLE[timestamp:NATURAL_32; mouse_state:GAME_MOUSE_EVENT_ORIGIN;
 																	delta_x,delta_y:INTEGER_32]]
 			-- Internal value of the `mouse_wheel_move_actions' lazy evaluated attribute
 
@@ -808,7 +808,7 @@ feature {NONE} -- Implementation
 			-- The dispatcher receiving event from the `mouse_wheel_move_events_callback' and dispatch them to
 			-- the `mouse_wheel_move_actions' {ACTION_SEQUENCE}
 		local
-			l_mouse_state:GAME_MOUSE_EVENTS_STATE
+			l_mouse_state:GAME_MOUSE_EVENT_ORIGIN
 		do
 			if a_window_id =id or a_window_id = 0 then
 				if attached mouse_wheel_move_actions_internal as actions then


### PR DESCRIPTION
L'invariant de la classe GAME_MOUSE_BUTTON_PRESSED_STATE peut être simplifié.

Quelle est l'erreur avec le pavé tactile sous Linux? Est-ce toujours d'actualité? Je n'arrive pas à en produire de mon côté (sous openSUSE Tumbleweed).