### PR TITLE
Maintenance "obsolete [2017-05-31]"

### DIFF
--- a/game_core/graphic/game_color_palette.e
+++ b/game_core/graphic/game_color_palette.e
@@ -89,7 +89,7 @@ feature -- Access
 		require else
 			Palette_Exist: exists
 		do
-			Result := (i >= index_set.lower) and (i <= index_set.upper)
+			Result := (i >= lower) and (i <= upper)
 		end
 
 	at alias "[]" (a_index:INTEGER):GAME_COLOR_READABLE assign put_i_th

--- a/game_core/graphic/game_window.e
+++ b/game_core/graphic/game_window.e
@@ -528,9 +528,9 @@ feature -- Access
 			l_red, l_green, l_blue:ARRAY[NATURAL_16]
 			l_error:INTEGER
 		do
-			create l_red.make(1, 256)
-			create l_green.make(1, 256)
-			create l_blue.make(1, 256)
+			create l_red.make_filled ({NATURAL_16} 0, 1, 256)
+			create l_green.make_filled ({NATURAL_16} 0, 1, 256)
+			create l_blue.make_filled ({NATURAL_16} 0, 1, 256)
 			l_error := {GAME_SDL_EXTERNAL}.SDL_GetWindowGammaRamp(item, $l_red, $l_green, $l_blue)
 			manage_error_code(l_error, "Cannot get gamma correction values.")
 			Result := [create {ARRAYED_LIST[NATURAL_16]}.make_from_array (l_red), create {ARRAYED_LIST[NATURAL_16]}.make_from_array (l_green), create {ARRAYED_LIST[NATURAL_16]}.make_from_array (l_blue)]


### PR DESCRIPTION
Certaines fonctionalités sont marquées obsolètes depuis le 31 mai 2017 et empêchent maintenant la compilation du projet.

```eiffel
ARRAY[G]

make (min_index, max_index: INTEGER)
    obsolete " `make' is not void-safe statically. Use `make_empty' or `make_filled' instead. [2017-05-31]"
```
```eiffel
READABLE_INDEXABLE [G]

index_set: INTEGER_INTERVAL
    obsolete "Use `lower' and `upper' instead. [2017-05-31]"
```