### PR TITLE
fix: Fixed GAME_SURFACE.draw_rectangle/s not accepting read-only colors

### DIFF
--- a/game_core/graphic/game_surface.e
+++ b/game_core/graphic/game_surface.e
@@ -359,7 +359,7 @@ feature -- Access
 									a_height_destination, True)
 		end
 
-	draw_rectangle(a_color:GAME_COLOR;a_x,a_y,a_width,a_height:INTEGER)
+	draw_rectangle(a_color:GAME_COLOR_READABLE;a_x,a_y,a_width,a_height:INTEGER)
 			-- Draw a `a_color' rectangle of dimension `a_width' x `a_height' on `Current' at (`a_x',`a_y').
 		require
 			Surface_Is_Video_Enable:game_library.is_video_enable
@@ -390,7 +390,7 @@ feature -- Access
 
 		end
 
-	draw_rectangles(a_color:GAME_COLOR;a_rectangles:CHAIN[TUPLE[x, y, width, height:INTEGER]])
+	draw_rectangles(a_color:GAME_COLOR_READABLE;a_rectangles:CHAIN[TUPLE[x, y, width, height:INTEGER]])
 			-- Drawing every `a_color' rectangle in `a_rectangles'
 			-- that has it's left frontier at
 			-- `x', it's top frontier at `y', with


### PR DESCRIPTION
`GAME_SURFACE.draw_rectangle` and `GAME_SURFACE.draw_rectangles` only read the color channels off the colors, red, green, blue, alpha..

This fixes the issue of trying to pass in a read-only color to these functions.